### PR TITLE
Inject console interceptor at document_start

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,41 +1,7 @@
 // Listen for extension icon click
 chrome.action.onClicked.addListener(async (tab) => {
-  // First inject early console interceptor
-  await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    func: function() {
-      // Store original console methods
-      window.__originalConsole = {
-        log: console.log,
-        info: console.info,
-        warn: console.warn,
-        error: console.error,
-        debug: console.debug,
-        trace: console.trace
-      };
-      
-      // Store messages until UI is ready
-      window.__consoleMessages = [];
-      
-      // Override console methods to store messages
-      Object.keys(window.__originalConsole).forEach(level => {
-        console[level] = (...args) => {
-          // Store message
-          window.__consoleMessages.push({
-            level,
-            args,
-            timestamp: new Date().toISOString(),
-            stack: new Error().stack
-          });
-          
-          // Call original
-          window.__originalConsole[level].apply(console, args);
-        };
-      });
-    }
-  });
 
-  // Then inject the main content script and styles
+  // Inject the main content script and styles
   await chrome.scripting.executeScript({
     target: { tabId: tab.id },
     files: ['content.js']

--- a/early-console.js
+++ b/early-console.js
@@ -1,28 +1,37 @@
-// Store original console methods
-window.__originalConsole = {
-  log: console.log,
-  info: console.info,
-  warn: console.warn,
-  error: console.error,
-  debug: console.debug,
-  trace: console.trace
-};
-
-// Store messages until UI is ready
-window.__consoleMessages = [];
-
-// Override console methods to store messages
-Object.keys(window.__originalConsole).forEach(level => {
-  console[level] = (...args) => {
-    // Store message
-    window.__consoleMessages.push({
-      level,
-      args,
-      timestamp: new Date().toISOString(),
-      stack: new Error().stack
-    });
-    
-    // Call original
-    window.__originalConsole[level].apply(console, args);
+// Only set up console interception if not already done
+if (!window.__consoleIntercepted) {
+  window.__consoleIntercepted = true;
+  
+  // Store original console methods
+  window.__originalConsole = {
+    log: console.log.bind(console),
+    info: console.info.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    debug: console.debug.bind(console),
+    trace: console.trace.bind(console)
   };
-});
+
+  // Store messages until UI is ready
+  window.__consoleMessages = [];
+
+  // Override console methods to store messages
+  Object.keys(window.__originalConsole).forEach(level => {
+    console[level] = (...args) => {
+      // Check if this is our own log to prevent recursion
+      const isInternalLog = new Error().stack.includes('early-console.js');
+      if (!isInternalLog) {
+        // Store message
+        window.__consoleMessages.push({
+          level,
+          args,
+          timestamp: new Date().toISOString(),
+          stack: new Error().stack
+        });
+        
+        // Call original
+        window.__originalConsole[level].apply(console, args);
+      }
+    };
+  });
+}

--- a/early-console.js
+++ b/early-console.js
@@ -1,0 +1,28 @@
+// Store original console methods
+window.__originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
+  trace: console.trace
+};
+
+// Store messages until UI is ready
+window.__consoleMessages = [];
+
+// Override console methods to store messages
+Object.keys(window.__originalConsole).forEach(level => {
+  console[level] = (...args) => {
+    // Store message
+    window.__consoleMessages.push({
+      level,
+      args,
+      timestamp: new Date().toISOString(),
+      stack: new Error().stack
+    });
+    
+    // Call original
+    window.__originalConsole[level].apply(console, args);
+  };
+});

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,13 @@
     "activeTab",
     "scripting"
   ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["early-console.js"],
+      "run_at": "document_start"
+    }
+  ],
   "background": {
     "service_worker": "background.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
     "activeTab",
     "scripting"
   ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
This PR modifies the extension to capture console logs from the very beginning of page load by:

- Adding early-console.js for early console interception
- Configuring content_script in manifest.json to run at document_start
- Removing early console injection from background.js

These changes ensure that all console logs are captured, including those that happen before the extension UI is initialized.